### PR TITLE
perl 5.34.3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -57,9 +57,17 @@ make
 # change permissions again after building
 chmod -R o-w "${SRC_DIR}"
 
+# 2017/6/17:
 # Seems we hit:
 # lib/perlbug .................................................... # Failed test 21 - [perl \#128020] long body lines are wrapped: maxlen 1157 at ../lib/perlbug.t line 154
 # FAILED at test 21
 # https://rt.perl.org/Public/Bug/Display.html?id=128020
+
+# 2023/12/18:
+# t/re/substT ...................................................... FAILED--expected 278 tests, saw 161
+# t/op/utftaint .................................................... FAILED--expected 89 tests, saw 86
+# porting/libperl.t: undefined current object: op.o: at porting/libperl.t line 242, <$nm_fh> line 2.
+# t/porting/libperl ................................................ FAILED--no leader found
 # make test
+
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -52,22 +52,18 @@ fi
 
 ./Configure "${_config_args[@]}" \
                 -de
-make
+make -j${CPU_COUNT}
 
 # change permissions again after building
 chmod -R o-w "${SRC_DIR}"
-
-# 2017/6/17:
-# Seems we hit:
-# lib/perlbug .................................................... # Failed test 21 - [perl \#128020] long body lines are wrapped: maxlen 1157 at ../lib/perlbug.t line 154
-# FAILED at test 21
-# https://rt.perl.org/Public/Bug/Display.html?id=128020
 
 # 2023/12/18:
 # t/re/substT ...................................................... FAILED--expected 278 tests, saw 161
 # t/op/utftaint .................................................... FAILED--expected 89 tests, saw 86
 # porting/libperl.t: undefined current object: op.o: at porting/libperl.t line 242, <$nm_fh> line 2.
 # t/porting/libperl ................................................ FAILED--no leader found
-# make test
+#make test
+# Verbose tests
+#make -j${CPU_COUNT} test_harness
 
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     # Additional be aware the the used sysroot is hard-coded in perl's
     # configuration at many places.  So on osx it means that SDK will be
     # searched at intially used place.  CONDA_BUILD_PREFIX is disregarded.
+
 test:
   commands:
     - perl --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,18 @@
-{% set unix_version = "5.34.0" %}
+{% set name = 'perl' %}
+{% set unix_version = "5.34.1" %}
 
 package:
-  name: perl
+  name: {{ name}}
   version: {{ unix_version }}
 
 source:
-  url: https://www.cpan.org/src/5.0/perl-{{ unix_version }}.tar.gz                                                 # [unix]
-  sha256: 551efc818b968b05216024fb0b727ef2ad4c100f8cb6b43fab615fa78ae5be9a                                        # [unix]
+  url: https://www.cpan.org/src/5.0/{{ name}}-{{ unix_version }}.tar.gz     # [unix]
+  sha256: 357951a491b0ba1ce3611263922feec78ccd581dddc24a446b033e25acf242a1  # [unix]
 
 build:
-  number: 2
+  number: 0
   # there is no Windows strawberry release of this version
+  # https://strawberryperl.com/releases.html
   skip: True  # [win]
 requirements:
   build:
@@ -30,6 +32,7 @@ requirements:
 test:
   commands:
     - perl --help
+    - perl -v
 
 about:
   home: https://www.perl.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'perl' %}
-{% set unix_version = "5.34.1" %}
+{% set unix_version = "5.34.3" %}
 
 package:
   name: {{ name}}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://www.cpan.org/src/5.0/{{ name}}-{{ unix_version }}.tar.gz     # [unix]
-  sha256: 357951a491b0ba1ce3611263922feec78ccd581dddc24a446b033e25acf242a1  # [unix]
+  sha256: 5b12f62863332b2a5f54102af9cdf8c010877e4bf3294911edbd594b2a1e8ede  # [unix]
 
 build:
   number: 0


### PR DESCRIPTION
perl 5.34.3 

**Destination channel:** main

### Links

- [PKG-3308](https://anaconda.atlassian.net/browse/PKG-3308) 
- [Upstream repository](https://github.com/Perl/perl5/tree/v5.34.3)
- [Diff 5.34.0..5.34.3](https://github.com/Perl/perl5/compare/v5.34.0...v5.34.3)

### Explanation of changes:

- Reset the build number to `0`
- Add a URL https://strawberryperl.com/releases.html  to the comment about Windows strawberry releases 
- Add `perl -v` to `test/commands`

### Notes:

- to address CVE-2022-48522 with a score of 9.8

[PKG-3308]: https://anaconda.atlassian.net/browse/PKG-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ