### PR TITLE
Pkg 3308

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -56,9 +56,7 @@ make
 # change permissions again after building
 chmod -R o-w "${SRC_DIR}"
 
-# Seems we hit:
-# lib/perlbug .................................................... # Failed test 21 - [perl \#128020] long body lines are wrapped: maxlen 1157 at ../lib/perlbug.t line 154
-# FAILED at test 21
-# https://rt.perl.org/Public/Bug/Display.html?id=128020
+# 1/13/2025
+# Still getting several failing tests, see: https://github.com/AnacondaRecipes/perl-feedstock/pull/11#issuecomment-2583033446
 # make test
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,7 +17,6 @@ fi
 
 export PATH=$PREFIX/bin:$PATH
 
-cp -f $PREFIX/include/ndbm.h $PREFIX/include/gdbm-ndbm.h
 # export CFLAGS="-I${PREFIX}/include"
 # export LDFLAGS="${LDFLAGS} -L${CONDA_BUILD_SYSROOT}/usr/lib"
 declare -a _config_args

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-CONDA_BUILD_SYSROOT:        # [osx and x86_64]
-  - /opt/MacOSX10.14.sdk    # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - 10.10                  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set unix_version = "5.38.2" %}
 {% set win_version = unix_version + ".2" %}
+{% set concat_version = win_version.split('.') | join('') %}
 
 package:
   name: perl
@@ -9,7 +10,7 @@ package:
 source:
   - url: http://www.cpan.org/src/5.0/perl-{{ unix_version }}.tar.xz                                                 # [unix]
     sha256: d91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8                                        # [unix]
-  - url: http://strawberryperl.com/download/{{ win_version }}/strawberry-perl-{{ win_version }}-64bit-portable.zip  # [win]
+  - url: https://github.com/StrawberryPerl/Perl-Dist-Strawberry/releases/download/SP_{{ concat_version }}_64bit/strawberry-perl-{{ win_version }}-64bit-portable.zip  # [win]
     sha256: ea451686065d6338d7e4d4a04c9af49f17951d15aa4c2e19ab8cb56fa2373440                                        # [win]
     # sha hashes published at: http://strawberryperl.com/releases.html
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,6 @@ requirements:
   host:
     - {{ compiler('c') }}   # [unix]
     - binutils              # [linux]
-    - gdbm                  # [unix]
-  run:
-    - gdbm >=1.18           # [unix]
     # If something needs to be compiled using Perl's C support,
     # you need to make sure the compiler is in same PREFIX as the perl
     # interpreter.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,21 @@
-{% set unix_version = "5.34.0" %}
+{% set unix_version = "5.38.2" %}
+{% set win_version = unix_version + ".2" %}
 
 package:
   name: perl
-  version: {{ unix_version }}
+  version: {{ unix_version }}  # [not win]
+  version: {{ win_version }}   # [win]
 
 source:
-  url: https://www.cpan.org/src/5.0/perl-{{ unix_version }}.tar.gz                                                 # [unix]
-  sha256: 551efc818b968b05216024fb0b727ef2ad4c100f8cb6b43fab615fa78ae5be9a                                        # [unix]
+  - url: http://www.cpan.org/src/5.0/perl-{{ unix_version }}.tar.xz                                                 # [unix]
+    sha256: d91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8                                        # [unix]
+  - url: http://strawberryperl.com/download/{{ win_version }}/strawberry-perl-{{ win_version }}-64bit-portable.zip  # [win]
+    sha256: ea451686065d6338d7e4d4a04c9af49f17951d15aa4c2e19ab8cb56fa2373440                                        # [win]
+    # sha hashes published at: http://strawberryperl.com/releases.html
 
 build:
-  number: 2
-  # there is no Windows strawberry release of this version
-  skip: True  # [win]
+  number: 0
+
 requirements:
   build:
     - make                  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ source:
 
 build:
   number: 0
+  string: {{ PKG_BUILDNUM }}_h{{ PKG_HASH }}_strawberry  # [win]
+  string: {{ PKG_BUILDNUM }}_h{{ PKG_HASH }}_perl5       # [not win]
 
 requirements:
   build:


### PR DESCRIPTION
perl v5.38.2
**Destination channel:**  defaults

### Links

- [PKG-3308](https://anaconda.atlassian.net/browse/PKG-3308) 
- [Upstream repository](https://github.com/Perl/perl5/tree/v5.38.2)
- [Upstream changelog/diff](https://github.com/Perl/perl5/compare/v5.34.0...v5.38.2)

### Explanation of changes:

- I chose a version that satisfies ` >=5.34.1 and/or >=5.35.5` and that was on the list of Recommended downloads here: https://strawberryperl.com/releases.html
- Add back re-packing of windows from Strawberry Perl
- Bump version and SHAs. 


[PKG-3308]: https://anaconda.atlassian.net/browse/PKG-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ