### PR TITLE
perl 5.43.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set unix_version = "5.42.2" %}
+{% set unix_version = "5.43.11" %}
 {% set win_version = unix_version + ".1" %}
 
 package:
@@ -7,15 +7,16 @@ package:
   version: {{ win_version }}   # [win]
 
 source:
-  - url: https://cpan.org/src/5.0/perl-{{ unix_version }}.tar.xz
-    sha256: 0a585eeb9e363c0f80482ddb3571625250c2c86aeb408853e8ea50805cfb14bb
+  # CPAN /src/5.0/perl-5.43.11.tar.{xz,gz} not published yet; use upstream tag archive.
+  - url: https://github.com/Perl/perl5/archive/refs/tags/v{{ unix_version }}.tar.gz
+    sha256: 954d3d3ed0f7cde19267d007c57540fb7d873ec9019c2f3573163828a7001010
     patches:
       # conda binary prefix replacement pads shorter paths with NUL inside the
       # fixed-width literal; STR_WITH_LEN still passes sizeof()-1 → broken @INC.
       - patches/0001-S_mayberelocate-truncate-after-binary-prefix-padding.patch  # [unix]
 
 build:
-  number: 1
+  number: 0
   string: {{ PKG_BUILDNUM }}_h{{ PKG_HASH }}_perl5
 
 requirements:


### PR DESCRIPTION
## perl 5.43.11

**Destination channel:** defaults

### Links
- [PKG-15184](https://anaconda.atlassian.net/browse/PKG-15184)
- [Upstream tag v5.43.11](https://github.com/Perl/perl5/tree/v5.43.11)
- [CPAN source index](https://www.cpan.org/src/5.0/)

### Explanation of changes
- Updated perl from 5.42.2 to 5.43.11 (development release)
- Reset build number to 0
- Source from GitHub tag archive — CPAN `perl-5.43.11.tar.{xz,gz}` returns 404 as of 2026-06-05; switch to CPAN URL when published
- Retained `@INC` NUL-padding patch (applies cleanly to 5.43.11)
- Retained Config sysroot scrub

### Test plan
- [ ] CI graph completes on linux-64, linux-aarch64, osx-64, osx-arm64, win-64
- [ ] `perl --help` and Config smoke tests pass on unix

Made with [Cursor](https://cursor.com)

[PKG-15184]: https://anaconda.atlassian.net/browse/PKG-15184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ