### PR TITLE
perl win-arm64 compat

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,14 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "$p = [regex]::Replace($p, '(^\s*INST_TOP\s*=).*$', '${1} ' + $env:LIBRARY_PREFIX, [Text.RegularExpressions.RegexOptions]::Multiline); " ^
   "[System.IO.File]::WriteAllText('Makefile', $p, [System.Text.Encoding]::ASCII)"
 
-nmake
-nmake test || echo Ignoring test failure
-nmake install
+:: Build with architecture-specific parameters
+if "%target_platform%"=="win-arm64" (
+  echo Building for ARM64
+  nmake WIN64=define PROCESSOR_ARCHITECTURE=ARM64
+  nmake WIN64=define PROCESSOR_ARCHITECTURE=ARM64 test || echo Ignoring test failure
+  nmake WIN64=define PROCESSOR_ARCHITECTURE=ARM64 install
+) else (
+  nmake
+  nmake test || echo Ignoring test failure
+  nmake install
+)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - patches/0001-S_mayberelocate-truncate-after-binary-prefix-padding.patch  # [unix]
 
 build:
-  number: 1
+  number: 2
   string: {{ PKG_BUILDNUM }}_h{{ PKG_HASH }}_perl5
 
 requirements:


### PR DESCRIPTION
perl win-arm64 compat

**Destination channel:**  defaults

### Links

- [PKG-15385](https://anaconda.atlassian.net/browse/PKG-15385) 

### Explanation of changes:

- Bump build number
- Update nmake calls to correctly build on win-arm64


[PKG-15385]: https://anaconda.atlassian.net/browse/PKG-15385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ